### PR TITLE
[refactor]-JWT

### DIFF
--- a/src/main/java/com/dangbun/domain/user/controller/UserController.java
+++ b/src/main/java/com/dangbun/domain/user/controller/UserController.java
@@ -6,7 +6,6 @@ import com.dangbun.domain.user.entity.User;
 import com.dangbun.domain.user.response.status.UserExceptionResponse;
 import com.dangbun.domain.user.service.UserCommandService;
 import com.dangbun.domain.user.service.UserQueryService;
-import com.dangbun.domain.user.service.UserService;
 import com.dangbun.global.docs.DocumentedApiErrors;
 import com.dangbun.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/dangbun/domain/user/controller/UserController.java
+++ b/src/main/java/com/dangbun/domain/user/controller/UserController.java
@@ -4,6 +4,8 @@ import com.dangbun.domain.user.dto.request.*;
 import com.dangbun.domain.user.dto.response.PostUserLoginResponse;
 import com.dangbun.domain.user.entity.User;
 import com.dangbun.domain.user.response.status.UserExceptionResponse;
+import com.dangbun.domain.user.service.UserCommandService;
+import com.dangbun.domain.user.service.UserQueryService;
 import com.dangbun.domain.user.service.UserService;
 import com.dangbun.global.docs.DocumentedApiErrors;
 import com.dangbun.global.response.BaseResponse;
@@ -27,7 +29,8 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
 
-    private final UserService userService;
+    private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
 
     @Operation(summary = "인증번호 생성(비밀번호 재설정용)",description = "이메일 인증번호를 생성합니다.(비밀번호 재설정 용)")
     @DocumentedApiErrors(
@@ -37,7 +40,7 @@ public class UserController {
     @PostMapping("/email-code")
     public ResponseEntity<BaseResponse<?>> generatePasswordAuthCode(@RequestBody PostUserAuthCodeRequest request) {
         String email = request.email();
-        userService.sendFindPasswordAuthCode(email);
+        userQueryService.sendFindPasswordAuthCode(email);
         return ResponseEntity.ok(BaseResponse.ok(null));
     }
 
@@ -49,7 +52,7 @@ public class UserController {
     @PostMapping("/signup/email-code")
     public ResponseEntity<BaseResponse<?>> generateSignupAuthCode(@RequestBody PostUserAuthCodeRequest request) {
         String email = request.email();
-        userService.sendSignupAuthCode(email);
+        userCommandService.sendSignupAuthCode(email);
         return ResponseEntity.ok(BaseResponse.ok(null));
     }
 
@@ -61,7 +64,7 @@ public class UserController {
     )
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<?>> signUp(@RequestBody PostUserSignUpRequest request) {
-        userService.signup(request);
+        userCommandService.signup(request);
         return ResponseEntity.ok(BaseResponse.ok(null));
     }
 
@@ -72,7 +75,7 @@ public class UserController {
     )
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<PostUserLoginResponse>> login(@RequestBody PostUserLoginRequest request) {
-        return ResponseEntity.ok(BaseResponse.ok(userService.login(request)));
+        return ResponseEntity.ok(BaseResponse.ok(userQueryService.login(request)));
     }
 
 
@@ -83,7 +86,7 @@ public class UserController {
     )
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<?>> logout(@RequestHeader("Authorization") String bearerToken) {
-        userService.logout(bearerToken);
+        userQueryService.logout(bearerToken);
         return ResponseEntity.ok(BaseResponse.ok(null));
 
     }
@@ -96,7 +99,7 @@ public class UserController {
     )
     @PostMapping("/me/password")
     public ResponseEntity<BaseResponse<?>> updatePassword(@RequestBody @Valid PostUserPasswordUpdateRequest request) {
-        userService.updatePassword(request);
+        userCommandService.updatePassword(request);
         return ResponseEntity.ok(BaseResponse.ok(null));
     }
 
@@ -109,7 +112,7 @@ public class UserController {
     @DeleteMapping("/me")
     public ResponseEntity<BaseResponse<?>> deleteCurrentUser(@AuthenticationPrincipal(expression = "user") User user,
                                                              @RequestBody DeleteUserAccountRequest request) {
-        userService.deleteCurrentUser(user, request);
+        userCommandService.deleteCurrentUser(user, request);
         return ResponseEntity.ok(BaseResponse.ok(null));
     }
 
@@ -123,7 +126,7 @@ public class UserController {
             @AuthenticationPrincipal(expression = "user") User user
     ) {
 
-        return ResponseEntity.ok(BaseResponse.ok(userService.getMyInfo(user)));
+        return ResponseEntity.ok(BaseResponse.ok(userQueryService.getMyInfo(user)));
     }
 
 }

--- a/src/main/java/com/dangbun/domain/user/service/AuthCodeService.java
+++ b/src/main/java/com/dangbun/domain/user/service/AuthCodeService.java
@@ -34,7 +34,7 @@ public class AuthCodeService {
         authRedisService.saveAuthCode(AUTH_CODE_PREFIX + toEmail, authCode, Duration.ofMillis(this.authCodeExpirationMillis));
     }
 
-    public void checkCertCode(String email, String authCode) {
+    public void checkAuthCode(String email, String authCode) {
         if (!authRedisService.getAuthCode(AUTH_CODE_PREFIX + email).equals(authCode)) {
             throw new InvalidCertCodeException(INVALID_CERT_CODE);
         }

--- a/src/main/java/com/dangbun/domain/user/service/AuthCodeService.java
+++ b/src/main/java/com/dangbun/domain/user/service/AuthCodeService.java
@@ -1,0 +1,56 @@
+package com.dangbun.domain.user.service;
+
+import com.dangbun.domain.user.exception.custom.InvalidCertCodeException;
+import com.dangbun.global.email.EmailService;
+import com.dangbun.global.redis.AuthRedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Random;
+
+import static com.dangbun.domain.user.response.status.UserExceptionResponse.INVALID_CERT_CODE;
+
+@RequiredArgsConstructor
+@Service
+public class AuthCodeService {
+
+    private final EmailService emailService;
+    private final AuthRedisService authRedisService;
+
+    private static final String AUTH_CODE_PREFIX = "AuthCode";
+
+
+    @Value("${spring.mail.auth-code-expiration-millis}")
+    private Long authCodeExpirationMillis;
+
+    public void sendAuthCode(String toEmail){
+        String title = "당번 이메일 인증 번호";
+        String authCode = createAuthCode();
+        emailService.sendEmail(toEmail, title, authCode);
+        authRedisService.saveAuthCode(AUTH_CODE_PREFIX + toEmail, authCode, Duration.ofMillis(this.authCodeExpirationMillis));
+    }
+
+    public void checkCertCode(String email, String authCode) {
+        if (!authRedisService.getAuthCode(AUTH_CODE_PREFIX + email).equals(authCode)) {
+            throw new InvalidCertCodeException(INVALID_CERT_CODE);
+        }
+    }
+
+    private String createAuthCode() {
+        int length = 6;
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < length; i++) {
+                builder.append(random.nextInt(10));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/src/main/java/com/dangbun/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/dangbun/domain/user/service/UserCommandService.java
@@ -22,11 +22,12 @@ import static com.dangbun.domain.user.response.status.UserExceptionResponse.*;
 @RequiredArgsConstructor
 @Service
 public class UserCommandService {
+
     private final AuthCodeService authCodeService;
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     private static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$";
-    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void sendSignupAuthCode(String toEmail) {

--- a/src/main/java/com/dangbun/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/dangbun/domain/user/service/UserQueryService.java
@@ -1,0 +1,80 @@
+package com.dangbun.domain.user.service;
+
+import com.dangbun.domain.user.dto.request.PostUserLoginRequest;
+import com.dangbun.domain.user.dto.response.GetUserMyInfoResponse;
+import com.dangbun.domain.user.dto.response.PostUserLoginResponse;
+import com.dangbun.domain.user.entity.User;
+import com.dangbun.domain.user.exception.custom.DeleteMemberException;
+import com.dangbun.domain.user.exception.custom.InvalidEmailException;
+import com.dangbun.domain.user.exception.custom.InvalidPasswordException;
+import com.dangbun.domain.user.exception.custom.NoSuchUserException;
+import com.dangbun.domain.user.repository.UserRepository;
+import com.dangbun.global.redis.AuthRedisService;
+import com.dangbun.global.security.refactor.JwtService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.dangbun.domain.user.response.status.UserExceptionResponse.*;
+import static com.dangbun.domain.user.response.status.UserExceptionResponse.INVALID_PASSWORD;
+import static com.dangbun.global.security.refactor.TokenName.ACCESS;
+import static com.dangbun.global.security.refactor.TokenName.REFRESH;
+
+@RequiredArgsConstructor
+@Service
+public class UserQueryService {
+    private final AuthCodeService authCodeService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthRedisService authRedisService;
+    private final JwtService jwtService;
+
+    @Transactional(readOnly = true)
+    public void sendFindPasswordAuthCode(String toEmail) {
+        if (getUserByEmail(toEmail).isPresent()) {
+            authCodeService.sendAuthCode(toEmail);
+        } else{
+            throw new InvalidEmailException(INVALID_EMAIL);
+        }
+    }
+
+
+    @Transactional(readOnly = true)
+    public PostUserLoginResponse login(@Valid PostUserLoginRequest request) {
+
+
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new NoSuchUserException(NO_SUCH_USER));
+
+        if (!user.getEnabled()) {
+            throw new DeleteMemberException(DELETE_MEMBER);
+        }
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new InvalidPasswordException(INVALID_PASSWORD);
+        }
+
+        Map<String, String> tokenMap = jwtService.generateToken(user);
+        authRedisService.saveRefreshToken(user.getUserId(), tokenMap.get(REFRESH.getName()));
+
+        return new PostUserLoginResponse(tokenMap.get(ACCESS.getName()), tokenMap.get(REFRESH.getName()));
+    }
+
+    public void logout(String bearerToken) {
+        authRedisService.deleteAndSetBlacklist(bearerToken);
+    }
+
+    public GetUserMyInfoResponse getMyInfo(User user) {
+        return GetUserMyInfoResponse.from(user);
+    }
+
+    private Optional<User> getUserByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+}

--- a/src/main/java/com/dangbun/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/dangbun/domain/user/service/UserQueryService.java
@@ -28,6 +28,7 @@ import static com.dangbun.global.security.refactor.TokenName.REFRESH;
 @RequiredArgsConstructor
 @Service
 public class UserQueryService {
+
     private final AuthCodeService authCodeService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/com/dangbun/domain/user/service/UserService.java
+++ b/src/main/java/com/dangbun/domain/user/service/UserService.java
@@ -37,7 +37,6 @@ import static com.dangbun.domain.user.response.status.UserExceptionResponse.*;
 import static com.dangbun.global.security.refactor.TokenName.*;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class UserService {
 
@@ -55,6 +54,7 @@ public class UserService {
     private Long authCodeExpirationMillis;
 
 
+    @Transactional(readOnly = true)
     public void sendFindPasswordAuthCode(String toEmail) {
         if (getUserByEmail(toEmail).isPresent()) {
             sendAuthCode(toEmail);
@@ -63,7 +63,7 @@ public class UserService {
         }
     }
 
-
+    @Transactional
     public void sendSignupAuthCode(String toEmail) {
         if (getUserByEmail(toEmail).isEmpty()) {
             sendAuthCode(toEmail);
@@ -98,6 +98,7 @@ public class UserService {
         }
     }
 
+    @Transactional
     public void signup(@Valid PostUserSignUpRequest request) {
 
         String name = request.name();
@@ -138,6 +139,7 @@ public class UserService {
         return password != null && password.matches(PASSWORD_PATTERN);
     }
 
+    @Transactional
     public void updatePassword(@Valid PostUserPasswordUpdateRequest request) {
 
         User user = userRepository.findByEmail(request.email())
@@ -154,6 +156,7 @@ public class UserService {
 
     }
 
+    @Transactional
     public void deleteCurrentUser(User user, DeleteUserAccountRequest request) {
         if (request.email() != null && user.getEmail().equals(request.email())) {
             user.deactivate();
@@ -163,6 +166,7 @@ public class UserService {
         throw new InvalidEmailException(INVALID_EMAIL);
     }
 
+    @Transactional(readOnly = true)
     public PostUserLoginResponse login(@Valid PostUserLoginRequest request) {
 
 

--- a/src/main/java/com/dangbun/global/redis/AuthRedisService.java
+++ b/src/main/java/com/dangbun/global/redis/AuthRedisService.java
@@ -1,0 +1,35 @@
+package com.dangbun.global.redis;
+
+import com.dangbun.global.security.JwtUtil;
+import com.dangbun.global.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Service
+public class AuthRedisService {
+    private final StringRedisTemplate redisTemplate;
+    private final JwtUtil jwtUtil;
+    private final TokenProvider tokenProvider;
+
+    public void deleteAndSetBlacklist(String bearerToken){
+        String accessToken = jwtUtil.parseAccessToken(bearerToken);
+        String userId = tokenProvider.validateAndGetUserId(accessToken);
+
+
+
+        redisTemplate.delete("refreshToken:" + userId);
+
+        Date expiration = jwtUtil.getExpiration(accessToken);
+        Long now = System.currentTimeMillis();
+        Long expirationMs = expiration.getTime() - now;
+
+        redisTemplate.opsForValue()
+                .set("blacklist:" + accessToken, "logout", expirationMs, TimeUnit.MILLISECONDS);
+    }
+}
+

--- a/src/main/java/com/dangbun/global/redis/AuthRedisService.java
+++ b/src/main/java/com/dangbun/global/redis/AuthRedisService.java
@@ -10,14 +10,16 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import static com.dangbun.global.security.TokenProvider.REFRESH_VALIDATION_MS;
-
 @RequiredArgsConstructor
 @Service
 public class AuthRedisService {
+
     private final StringRedisTemplate redisTemplate;
     private final JwtUtil jwtUtil;
     private final TokenProvider tokenProvider;
+
+    public final static Long REFRESH_VALIDATION_MS = 1000L * 60 * 60 * 24 * 15;
+
 
     public void deleteAndSetBlacklist(String bearerToken){
         String accessToken = jwtUtil.parseAccessToken(bearerToken);
@@ -38,6 +40,15 @@ public class AuthRedisService {
     public void saveRefreshToken(Long userId, String refreshToken) {
         redisTemplate.opsForValue()
                 .set("refreshToken:" + userId, refreshToken, Duration.ofMillis(REFRESH_VALIDATION_MS));
+    }
+
+    public void saveAuthCode(String toEmail, String authCode, Duration duration){
+        redisTemplate.opsForValue()
+                .set(toEmail, authCode, duration);
+    }
+
+    public String getAuthCode(String email) {
+        return redisTemplate.opsForValue().get(email);
     }
 }
 

--- a/src/main/java/com/dangbun/global/redis/AuthRedisService.java
+++ b/src/main/java/com/dangbun/global/redis/AuthRedisService.java
@@ -6,8 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
+import static com.dangbun.global.security.TokenProvider.REFRESH_VALIDATION_MS;
 
 @RequiredArgsConstructor
 @Service
@@ -30,6 +33,11 @@ public class AuthRedisService {
 
         redisTemplate.opsForValue()
                 .set("blacklist:" + accessToken, "logout", expirationMs, TimeUnit.MILLISECONDS);
+    }
+
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        redisTemplate.opsForValue()
+                .set("refreshToken:" + userId, refreshToken, Duration.ofMillis(REFRESH_VALIDATION_MS));
     }
 }
 

--- a/src/main/java/com/dangbun/global/redis/AuthRedisService.java
+++ b/src/main/java/com/dangbun/global/redis/AuthRedisService.java
@@ -16,14 +16,13 @@ public class AuthRedisService {
 
     private final StringRedisTemplate redisTemplate;
     private final JwtUtil jwtUtil;
-    private final TokenProvider tokenProvider;
 
     public final static Long REFRESH_VALIDATION_MS = 1000L * 60 * 60 * 24 * 15;
 
 
     public void deleteAndSetBlacklist(String bearerToken){
         String accessToken = jwtUtil.parseAccessToken(bearerToken);
-        String userId = tokenProvider.validateAndGetUserId(accessToken);
+        String userId = jwtUtil.validateAndGetUserId(accessToken);
 
 
 

--- a/src/main/java/com/dangbun/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dangbun/global/security/JwtAuthenticationFilter.java
@@ -38,19 +38,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
     private final RedisTemplate<Object, Object> redisTemplate;
-
     private final JwtUtil jwtUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-
-            String token = parseAccessToken(request);
+            String path = request.getRequestURI();
+            if(path.contains("/users/login")){
+                filterChain.doFilter(request, response);
+                return;
+            }
+            String token = jwtUtil.parseAccessToken(request.getHeader("Authorization"));
 
             log.info("jwt filter is running");
 
             if (token != null && !token.equalsIgnoreCase("null")) {
-                authenticate(request, response, token);
+                boolean authenticated = authenticate(request, response, token);
+                if (!authenticated) {
+                    return; // Stop filter chain if authentication failed
+                }
             }
             filterChain.doFilter(request, response);
         } catch (RuntimeException e) {
@@ -58,7 +64,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
     }
 
-    private void authenticate(HttpServletRequest request, HttpServletResponse response, String accessToken) {
+    private boolean authenticate(HttpServletRequest request, HttpServletResponse response, String accessToken) {
         try {
 
             String userId = jwtUtil.validateAndGetUserId(accessToken);
@@ -68,7 +74,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
             securityContext.setAuthentication(authentication);
             SecurityContextHolder.setContext(securityContext);
+            return true;
         } catch (ExpiredJwtException ex) {
+
             log.warn("Expired JWT token: {}", ex.getMessage());
             Cookie expiredCookie = new Cookie("accessToken", null);
             expiredCookie.setPath("/");
@@ -76,19 +84,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             expiredCookie.setHttpOnly(true);
             response.addCookie(expiredCookie);
 
-            response.setContentType("application/json;charset=UTF-8");
-            try {
-                response.getWriter().write("{\"code\":"+INVALID_JWT.getCode()+",\"message\":\"토큰이 만료되었습니다. 다시 로그인해주세요.\"}");
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            refreshAuthentication(request, response);
-
-            return;
+            return refreshAuthentication(request, response);
         }
     }
 
-    private void  refreshAuthentication(HttpServletRequest request, HttpServletResponse response)  {
+    private boolean refreshAuthentication(HttpServletRequest request, HttpServletResponse response)  {
         try {
             String refreshToken = getRefreshToken(request);
             Claims claims = jwtUtil.parseClaims(refreshToken);
@@ -108,13 +108,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             String newAccessToken = tokenProvider.createAccessToken(user);
             response.setHeader("Authorization", "Bearer " + newAccessToken);
+            return true;
 
         } catch (Exception e) {
             log.warn("refreshAuthentication 실패: {}", e.getMessage());
 
             SecurityContextHolder.clearContext();
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            throw new InvalidRefreshJWTException(INVALID_REFRESH_TOKEN);
+            response.setContentType("application/json;charset=UTF-8");
+            try {
+                response.getWriter().write("{\"code\":"+INVALID_JWT.getCode()+",\"message\":\"토큰이 만료되었습니다. 다시 로그인해주세요.\"}");
+            } catch (IOException ex) {
+                log.error("Error writing response", ex);
+            }
+            return false;
         }
     }
 
@@ -148,14 +155,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return authentication;
     }
 
-    private String parseAccessToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
 
     private String getRefreshToken(HttpServletRequest request) {
         try {

--- a/src/main/java/com/dangbun/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dangbun/global/security/JwtAuthenticationFilter.java
@@ -34,9 +34,12 @@ import static com.dangbun.global.response.status.BaseExceptionResponse.*;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
     private final RedisTemplate<Object, Object> redisTemplate;
+
+    private final JwtUtil jwtUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -58,7 +61,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void authenticate(HttpServletRequest request, HttpServletResponse response, String accessToken) {
         try {
 
-            String userId = tokenProvider.validateAndGetUserId(accessToken);
+            String userId = jwtUtil.validateAndGetUserId(accessToken);
             log.info("Authenticated user ID : " + userId);
             AbstractAuthenticationToken authentication = createAuthenticationToken(request, userId);
 
@@ -88,7 +91,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void  refreshAuthentication(HttpServletRequest request, HttpServletResponse response)  {
         try {
             String refreshToken = getRefreshToken(request);
-            Claims claims = tokenProvider.parseClaims(refreshToken);
+            Claims claims = jwtUtil.parseClaims(refreshToken);
             if (!isValidRefreshToken(refreshToken,claims)) {
                 throw new RuntimeException("Invalid refresh Token");
             }

--- a/src/main/java/com/dangbun/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dangbun/global/security/JwtAuthenticationFilter.java
@@ -60,6 +60,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
             filterChain.doFilter(request, response);
         } catch (RuntimeException e) {
+            createErrorResponse(response);
             logger.error(e);
         }
     }
@@ -114,13 +115,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.warn("refreshAuthentication 실패: {}", e.getMessage());
 
             SecurityContextHolder.clearContext();
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json;charset=UTF-8");
-            try {
-                response.getWriter().write("{\"code\":"+INVALID_JWT.getCode()+",\"message\":\"토큰이 만료되었습니다. 다시 로그인해주세요.\"}");
-            } catch (IOException ex) {
-                log.error("Error writing response", ex);
-            }
+            createErrorResponse(response);
             return false;
         }
     }
@@ -169,5 +164,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             logger.error(e);
         }
         return null;
+    }
+
+    private static void createErrorResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        try {
+            response.getWriter().write("{\"code\":"+INVALID_JWT.getCode()+",\"message\":\"토큰이 만료되었습니다. 다시 로그인해주세요.\"}");
+        } catch (IOException ex) {
+            log.error("Error writing response", ex);
+        }
     }
 }

--- a/src/main/java/com/dangbun/global/security/JwtService.java
+++ b/src/main/java/com/dangbun/global/security/JwtService.java
@@ -1,7 +1,0 @@
-package com.dangbun.global.security;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class JwtService {
-}

--- a/src/main/java/com/dangbun/global/security/JwtService.java
+++ b/src/main/java/com/dangbun/global/security/JwtService.java
@@ -1,0 +1,7 @@
+package com.dangbun.global.security;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+}

--- a/src/main/java/com/dangbun/global/security/JwtUtil.java
+++ b/src/main/java/com/dangbun/global/security/JwtUtil.java
@@ -1,45 +1,83 @@
 package com.dangbun.global.security;
 
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Base64;
 import java.util.Date;
 
 @Component
 public class JwtUtil {
-    public final static Long ACCESS_TOKEN_MS = 1000L * 60 * 60 * 24 * 15;
-    public final static Long REFRESH_TOKEN_MS = 1000L * 60 * 60 * 24 * 15;
 
-    @Value("${jwt.secret}")
-    private String SECRET;
+    private final String secret;
+
     private Key key;
+    private JwtParser parser;
 
+    public JwtUtil(@Value("${jwt.secret") String secret) {
+        this.secret = secret;
+    }
 
     @PostConstruct
-    public void init(){
-        this.key = Keys.hmacShaKeyFor(SECRET.getBytes());
+    void init() {
+        byte[] secretBytes = tryBase64Decode(secret);
+        if (secretBytes == null) { // 평문이라면 UTF-8 바이트 사용
+            secretBytes = secret.getBytes(StandardCharsets.UTF_8);
+        }
+        this.key = Keys.hmacShaKeyFor(secretBytes);
+
+        this.parser = Jwts.parserBuilder()
+                .setSigningKey(this.key)
+                .build();
     }
 
-    public String parseAccessToken(String bearerToken) {
-        return bearerToken.replace("Bearer ", "");
+    private byte[] tryBase64Decode(String s) {
+        try {
+            return Base64.getDecoder().decode(s);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
-    public Claims parseClaims(String token){
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
+    public String parseAccessToken(String authorizationHeader) {
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            throw new IllegalArgumentException("Authorization header is empty");
+        }
+        final String prefix = "Bearer ";
+        if (!authorizationHeader.startsWith(prefix)) {
+            throw new IllegalArgumentException("Authorization header must start with 'Bearer '");
+        }
+        String token = authorizationHeader.substring(prefix.length()).trim();
+        if (token.isEmpty()) {
+            throw new IllegalArgumentException("Bearer token is empty");
+        }
+        return token;    }
+
+    public Claims parseClaims(String token) {
+        return parser
                 .parseClaimsJws(token)
                 .getBody();
     }
 
-    public Date getExpiration(String token){
+    public Date getExpiration(String token) {
         return parseClaims(token).getExpiration();
     }
+
+    public String validateAndGetUserId(String token) {
+        try{
+            return parseClaims(token).getSubject();
+        }catch (ExpiredJwtException e){
+            throw e;
+        } catch (UnsupportedJwtException | MalformedJwtException e){
+            throw e;
+        }
+    }
+
 
 }

--- a/src/main/java/com/dangbun/global/security/JwtUtil.java
+++ b/src/main/java/com/dangbun/global/security/JwtUtil.java
@@ -20,7 +20,7 @@ public class JwtUtil {
     private Key key;
     private JwtParser parser;
 
-    public JwtUtil(@Value("${jwt.secret") String secret) {
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
         this.secret = secret;
     }
 
@@ -57,7 +57,8 @@ public class JwtUtil {
         if (token.isEmpty()) {
             throw new IllegalArgumentException("Bearer token is empty");
         }
-        return token;    }
+        return token;
+    }
 
     public Claims parseClaims(String token) {
         return parser
@@ -70,11 +71,11 @@ public class JwtUtil {
     }
 
     public String validateAndGetUserId(String token) {
-        try{
+        try {
             return parseClaims(token).getSubject();
-        }catch (ExpiredJwtException e){
+        } catch (ExpiredJwtException e) {
             throw e;
-        } catch (UnsupportedJwtException | MalformedJwtException e){
+        } catch (UnsupportedJwtException | MalformedJwtException e) {
             throw e;
         }
     }

--- a/src/main/java/com/dangbun/global/security/JwtUtil.java
+++ b/src/main/java/com/dangbun/global/security/JwtUtil.java
@@ -15,22 +15,16 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
-    private final String secret;
+    @Value("${jwt.secret}")
+    private String SECRET;
 
     private Key key;
     private JwtParser parser;
 
-    public JwtUtil(@Value("${jwt.secret}") String secret) {
-        this.secret = secret;
-    }
 
     @PostConstruct
     void init() {
-        byte[] secretBytes = tryBase64Decode(secret);
-        if (secretBytes == null) { // 평문이라면 UTF-8 바이트 사용
-            secretBytes = secret.getBytes(StandardCharsets.UTF_8);
-        }
-        this.key = Keys.hmacShaKeyFor(secretBytes);
+        this.key = Keys.hmacShaKeyFor(SECRET.getBytes());
 
         this.parser = Jwts.parserBuilder()
                 .setSigningKey(this.key)

--- a/src/main/java/com/dangbun/global/security/JwtUtil.java
+++ b/src/main/java/com/dangbun/global/security/JwtUtil.java
@@ -13,8 +13,8 @@ import java.util.Date;
 
 @Component
 public class JwtUtil {
-    public final static Long TOKEN_VALIDATION_MS = 1000L * 60 * 60 * 24 * 15;
-    public final static Long REFRESH_VALIDATION_MS = 1000L * 60 * 60 * 24 * 15;
+    public final static Long ACCESS_TOKEN_MS = 1000L * 60 * 60 * 24 * 15;
+    public final static Long REFRESH_TOKEN_MS = 1000L * 60 * 60 * 24 * 15;
 
     @Value("${jwt.secret}")
     private String SECRET;

--- a/src/main/java/com/dangbun/global/security/TokenProvider.java
+++ b/src/main/java/com/dangbun/global/security/TokenProvider.java
@@ -28,6 +28,7 @@ public class TokenProvider {
 
     public final static Long TOKEN_VALIDATION_MS = 1000L * 60 * 60 * 24 * 15;
     public final static Long REFRESH_VALIDATION_MS = 1000L * 60 * 60 * 24 * 15;
+    public final static String issuer = "dangbun app";
 
 
     @PostConstruct
@@ -37,11 +38,11 @@ public class TokenProvider {
 
     public String createAccessToken(User user){
 
-        return buildToken(user.getUserId(), "dangbun app", "access");
+        return buildToken(user.getUserId(), issuer, "access");
     }
 
     public String createRefreshToken(User user){
-        return buildToken(user.getUserId(), "dangbun app", "refresh");
+        return buildToken(user.getUserId(), issuer, "refresh");
     }
 
     public String validateAndGetUserId(String token){

--- a/src/main/java/com/dangbun/global/security/TokenProvider.java
+++ b/src/main/java/com/dangbun/global/security/TokenProvider.java
@@ -2,19 +2,16 @@ package com.dangbun.global.security;
 
 
 import com.dangbun.domain.user.entity.User;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.security.Key;
-import java.time.Duration;
 import java.util.Date;
 
 @RequiredArgsConstructor
@@ -26,8 +23,8 @@ public class TokenProvider {
     private String SECRET;
     private Key key;
 
-    public final static Long TOKEN_VALIDATION_MS = 1000L * 60 * 60 * 24 * 15;
-    public final static Long REFRESH_VALIDATION_MS = 1000L * 60 * 60 * 24 * 15;
+    public final static Long ACCESS_TOKEN_MS = 1000L * 60 * 60 * 24 * 15;
+    public final static Long REFRESH_TOKEN_MS = 1000L * 60 * 60 * 24 * 15;
     public final static String issuer = "dangbun app";
 
 
@@ -45,25 +42,15 @@ public class TokenProvider {
         return buildToken(user.getUserId(), issuer, "refresh");
     }
 
-    public String validateAndGetUserId(String token){
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-
-        return  claims.getSubject();
-    }
-
 
     private String buildToken(Long userId, String issuer, String type){
         Date now = new Date();
         Date expiryDate;
 
         if ("access".equals(type)) {
-            expiryDate = new Date(now.getTime() + TOKEN_VALIDATION_MS);
+            expiryDate = new Date(now.getTime() + ACCESS_TOKEN_MS);
         } else if ("refresh".equals(type)) {
-            expiryDate = new Date(now.getTime() + REFRESH_VALIDATION_MS);
+            expiryDate = new Date(now.getTime() + REFRESH_TOKEN_MS);
         } else {
             throw new IllegalArgumentException("Invalid token type: " + type);
         }
@@ -78,17 +65,5 @@ public class TokenProvider {
                 .compact();
     }
 
-    public void saveRefreshToken(Long userId ,String token){
-        redisTemplate.opsForValue()
-                .set("refreshToken:"+userId, token, Duration.ofMillis(REFRESH_VALIDATION_MS));
-    }
-
-    public Claims parseClaims(String token){
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-    }
 
 }

--- a/src/main/java/com/dangbun/global/security/refactor/JwtService.java
+++ b/src/main/java/com/dangbun/global/security/refactor/JwtService.java
@@ -2,6 +2,7 @@ package com.dangbun.global.security.refactor;
 
 import com.dangbun.domain.user.entity.User;
 import com.dangbun.global.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -9,14 +10,12 @@ import java.util.Map;
 
 import static com.dangbun.global.security.refactor.TokenName.*;
 
+@RequiredArgsConstructor
 @Service
 public class JwtService {
 
     private final TokenProvider tokenProvider;
 
-    public JwtService(TokenProvider tokenProvider) {
-        this.tokenProvider = tokenProvider;
-    }
 
     public Map<String, String> generateToken(User user) {
 

--- a/src/main/java/com/dangbun/global/security/refactor/JwtService.java
+++ b/src/main/java/com/dangbun/global/security/refactor/JwtService.java
@@ -1,0 +1,33 @@
+package com.dangbun.global.security.refactor;
+
+import com.dangbun.domain.user.entity.User;
+import com.dangbun.global.security.TokenProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.dangbun.global.security.refactor.TokenName.*;
+
+@Service
+public class JwtService {
+
+    private final TokenProvider tokenProvider;
+
+    public JwtService(TokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    public Map<String, String> generateToken(User user) {
+
+        Map<String , String> tokenMap = new HashMap<>();
+
+        final String accessToken = tokenProvider.createAccessToken(user);
+        tokenMap.put(ACCESS.getName(),accessToken);
+
+        final String refreshToken = tokenProvider.createRefreshToken(user);
+        tokenMap.put(REFRESH.getName(), refreshToken);
+
+        return tokenMap;
+    }
+}

--- a/src/main/java/com/dangbun/global/security/refactor/TokenName.java
+++ b/src/main/java/com/dangbun/global/security/refactor/TokenName.java
@@ -1,0 +1,16 @@
+package com.dangbun.global.security.refactor;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenName {
+    ACCESS("accessToken"),
+
+    REFRESH("refreshToken");
+
+    private final String name;
+
+    TokenName(String name){
+        this.name = name;
+    }
+}


### PR DESCRIPTION
### JwtUtil, Token Provider 책임 분리
Token Provider은 토큰 생성 관련 메서드만 보유
나머지 parese, valid 와 같은 로직은 JwtUtil 클래스에 위임

### JwtService
도메인에서 Jwt 로직을 처리하기 위해 JwtUtil 및 Token Provider을 직접 호출하는 대신 JwtService에서 한번에 처리하도록 함

### JwtAuthFilter 로직 정리
토큰 검증 과정 리팩토링

### User 리팩토링
Jwt 관련 메서드 리팩토링